### PR TITLE
(MINOR) Support attachJob and launchJob URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "artificial-debug-extension",
   "displayName": "Artificial Inc. Workflow Debugger VSCode Extension",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publisher": "artificial",
   "description": "Enables debugging of Artificial, Inc. Workflows.",
   "author": {
@@ -60,7 +60,8 @@
   "main": "./dist/extension.js",
   "activationEvents": [
     "onDebugResolve:artificial-workflow",
-    "onDebugDynamicConfigurations:artificial-workflow"
+    "onDebugDynamicConfigurations:artificial-workflow",
+    "onUri:artificial.artificial-debug-extension"
   ],
   "workspaceTrust": {
     "request": "never"
@@ -69,6 +70,18 @@
     "breakpoints": [
       {
         "language": "python"
+      }
+    ],
+    "configuration": [
+      {
+        "title": "Artificial Workflow Debugging",
+        "properties": {
+          "artificial.workflow.debug.envFilePath": {
+            "type": "string",
+            "default": null,
+            "description": "Path to .env file to use for Artificial Workflows debug adapter"
+          }
+        }
       }
     ],
     "debuggers": [


### PR DESCRIPTION
Adds support for the `vscode://artificial.artificial-debug-extension/attachJob` and `launchJob` URLs that will be launched by buttons in the front-end. The URL handler for both dynamically constructs a launch config of the appropriate type and starts debugging with it.

This also adds an extension config setting for the envFilePath. Since there does not seem to be a way for the extension to query what launch configurations are active, it's not possible to get the .env file path that the user has put into a launch configuration. Instead, if the user puts e.g. `${workspaceFolder}/artificial.env` into their extension envFilePath, then the extension will add that value to any launch configs that don't already have `envFile` set, including the dynamic ones. 

@artificial-cassiano , the description for the config setting could use some wordsmithing, plus we should align on what the full setting path should be--this one in particular might be useful for other extension purposes later on, so maybe we want a path that's more general than `artificial.workflow.debug`.